### PR TITLE
chore: Add CODEOWNERS and autolabel tasks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @looker-open-source/cortex-eng

--- a/.github/workflows/p3-issue-label.yml
+++ b/.github/workflows/p3-issue-label.yml
@@ -1,0 +1,21 @@
+name: Label all new/reopened issues with P3
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues_p3:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["p3"]
+            })

--- a/.github/workflows/triage-issue-label.yml
+++ b/.github/workflows/triage-issue-label.yml
@@ -1,0 +1,20 @@
+name: Label issues that need triage
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues_p3:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["need triage"]
+            })


### PR DESCRIPTION
The CODEOWNERS file restricts PR requests to be only approved by members of the group cortex-eng.

The two workflows automagically tag new issues with "p3" and "need triage".